### PR TITLE
MyServices 4.0.1 (bug fixed)

### DIFF
--- a/MyServices/src/main/java/com/MyServices/Payment/Bill.java
+++ b/MyServices/src/main/java/com/MyServices/Payment/Bill.java
@@ -4,6 +4,6 @@ public interface Bill {
 	
 	public int getBill();
 	public int getAmount();
-	public void setAmount();
+	public void setAmount(int amount);
 
 }

--- a/MyServices/src/main/java/com/MyServices/Payment/ConcreteBill.java
+++ b/MyServices/src/main/java/com/MyServices/Payment/ConcreteBill.java
@@ -37,13 +37,9 @@ public class ConcreteBill implements Bill{
 		return amount;
 	}
 
+	@Override
 	public void setAmount(int amount) {
 		this.amount = amount;
 	}
 
-	@Override
-	public void setAmount() {
-		// TODO Auto-generated method stub
-		
-	}
 }

--- a/MyServices/src/main/java/com/MyServices/Payment/OverallDiscount.java
+++ b/MyServices/src/main/java/com/MyServices/Payment/OverallDiscount.java
@@ -26,7 +26,7 @@ public class OverallDiscount extends BillDecorator
 	}
 
 	@Override
-	public void setAmount() {
+	public void setAmount(int amount) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/MyServices/src/main/java/com/MyServices/Payment/PaymentControl.java
+++ b/MyServices/src/main/java/com/MyServices/Payment/PaymentControl.java
@@ -18,10 +18,11 @@ public class PaymentControl extends Discount{
 		if (serviceDiscount(payment.getServiceName()))
 		{
 			Bill billSerDisBill = new ServiceDiscount(bill);
+			bill.setAmount(billSerDisBill.getBill());
 			
 			if (overallDiscount(payment.getUID()))
 			{
-				Bill billOverallDisBill = new ServiceDiscount(billSerDisBill);
+				Bill billOverallDisBill = new ServiceDiscount(bill);
 				System.out.println("Service & Overall Discount Applied");
 				payment.setAmount(billOverallDisBill.getBill()); 
 			}

--- a/MyServices/src/main/java/com/MyServices/Payment/ServiceDiscount.java
+++ b/MyServices/src/main/java/com/MyServices/Payment/ServiceDiscount.java
@@ -28,7 +28,7 @@ public class ServiceDiscount extends BillDecorator {
 	}
 
 	@Override
-	public void setAmount() {
+	public void setAmount(int amount) {
 		// TODO Auto-generated method stub
 		
 	}


### PR DESCRIPTION
There was a bug while testing..
When two methods of discounting are applied, one of them overrides the other .. 
This bug appears because the setAmount() function was ignored and not accurately implemented..